### PR TITLE
Add simple local chatbot demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-README.MD
+# Local GPT Chatbot
+
+This project provides a lightweight local ChatGPT-like interface. The frontend is built with **React/TypeScript** using Vite and simple shadcn-inspired components. The backend is a minimal **FastAPI** application that calls a local model through **[Ollama](https://ollama.ai/)**.
+
+## Architecture
+
+```
+┌──────────┐        HTTP        ┌──────────┐
+│ frontend │  <------------->  │ backend  │
+└──────────┘                    └──────────┘
+                                    │
+                                    │ (subprocess)
+                                    ▼
+                                 Ollama
+```
+
+- **Frontend** (`/frontend`)
+  - Written in React/TypeScript.
+  - Displays chat messages in a modern layout with a text area at the bottom.
+  - Sends the user's message to the backend and renders the returned response.
+- **Backend** (`/backend`)
+  - Provides a `/chat` endpoint implemented with FastAPI.
+  - Uses the `ollama` CLI to run a local model and return its response.
+
+## Running
+
+Install Python and Node dependencies (see `requirements.txt` and `frontend/package.json`). Then use the provided script to start both parts:
+
+```bash
+./run_app.sh
+```
+
+The backend will run on `http://localhost:8000` and the frontend on `http://localhost:3000`.
+
+## Ollama
+
+[Ollama](https://ollama.ai/) allows you to run language models locally. Install it according to their documentation and make sure the `ollama` command is available in your `PATH`. You can specify the model name in the API request; by default the example leaves it empty so you can choose your own.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import subprocess
+
+app = FastAPI()
+
+class ChatRequest(BaseModel):
+    message: str
+    model: str = ""
+
+class ChatResponse(BaseModel):
+    response: str
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest):
+    if not req.message:
+        raise HTTPException(status_code=400, detail="Message is required")
+    # Call ollama command line to get a response
+    try:
+        # Example command: ollama run <model> -p <prompt>
+        model = req.model or ""  # default empty
+        process = subprocess.run(
+            ["ollama", "run", model, "-p", req.message],
+            check=True, capture_output=True, text=True
+        )
+        answer = process.stdout.strip()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return ChatResponse(response=answer)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Local GPT Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "local-gpt-ui",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview"
+  },
+  "dependencies": {
+    "react": "",
+    "react-dom": "",
+    "axios": ""
+  },
+  "devDependencies": {
+    "typescript": "",
+    "vite": "",
+    "@vitejs/plugin-react": ""
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './index.css';
+
+interface Message {
+  role: 'user' | 'agent';
+  content: string;
+}
+
+const App: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMsg: Message = { role: 'user', content: input };
+    setMessages(prev => [...prev, userMsg]);
+    setInput('');
+
+    try {
+      const res = await axios.post('http://localhost:8000/chat', { message: userMsg.content, model: '' });
+      const botMsg: Message = { role: 'agent', content: res.data.response };
+      setMessages(prev => [...prev, botMsg]);
+    } catch (e: any) {
+      const botMsg: Message = { role: 'agent', content: 'Error: ' + e.message };
+      setMessages(prev => [...prev, botMsg]);
+    }
+  };
+
+  return (
+    <div className="h-screen flex flex-col p-4">
+      <div className="flex-1 overflow-y-auto space-y-2">
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={`p-3 rounded-md max-w-lg ${m.role === 'user' ? 'bg-blue-600 text-white self-end ml-auto' : 'bg-gray-200 text-gray-900 mr-auto'}`}
+          >
+            {m.content}
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex">
+        <textarea
+          className="flex-1 border rounded-md p-2" rows={2}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button className="ml-2 px-4 py-2 bg-blue-600 text-white rounded-md" onClick={sendMessage}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,8 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+textarea {
+  resize: none;
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Start backend and frontend for local GPT chatbot
+
+# Start backend
+uvicorn backend.main:app --reload &
+BACKEND_PID=$!
+
+# Start frontend
+npm --prefix frontend run dev &
+FRONTEND_PID=$!
+
+# Wait for processes
+trap 'kill $BACKEND_PID $FRONTEND_PID' EXIT
+wait


### PR DESCRIPTION
## Summary
- set up FastAPI backend with Ollama chat endpoint
- create React frontend with shadcn inspired layout
- add run script to launch backend and frontend
- document architecture and usage
- declare minimal Python requirements

## Testing
- `git status --short`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686d6c8d25348325b4a01222bfd55d5a